### PR TITLE
more advanced error handling using blocks

### DIFF
--- a/source/CoreDataStack.h
+++ b/source/CoreDataStack.h
@@ -294,4 +294,15 @@ typedef void (^CoreDataStackErrorHandler)(CoreDataStack* stack, NSError* error);
  */
 -(void) wipeAllData;
 
+/** remove current database / persistent store and replace with a new one. A backup of the old database will be saved at the same position with appended extension .old
+@param newDatabaseURL the NSURL of the new database / persistent store, pass nil if you want to reset the current persistent store without loading a new database.
+*/
+-(void)replaceDatabaseWithURL:(NSURL*)newDatabaseURL;
+
+/** resets the current database / persistent store. A backup of the old database will be saved at the same position with appended extension .old
+    Convinience method for calling -replaceDatabaseWithURL:nil
+@see replaceDatabaseWithURL:
+*/
+-(void)resetDatabase;
+
 @end

--- a/source/CoreDataStack.h
+++ b/source/CoreDataStack.h
@@ -37,6 +37,10 @@ typedef enum CDSStoreType
 	CDSStoreTypeInMemory
 } CDSStoreType;
 
+@class CoreDataStack;
+
+typedef void (^CoreDataStackErrorHandler)(CoreDataStack* stack, NSError* error);
+
 @interface CoreDataStack : NSObject
 {
 	NSManagedObjectModel* _mom;
@@ -84,6 +88,9 @@ typedef enum CDSStoreType
 /** Very useful when developing an app: make "Failed saves" *immediately* Assert (pause the debugger), so you can quickly debug them,
  instead of silently failing and you not noticing that your in-memory data is corrupt! */
 @property(nonatomic) BOOL shouldAssertWhenSaveFails;
+
+/** add a handler block for errors that could happen in persistent store creation or updating. Called whenever no other error handling block is explicitly passed as parameter to any of this classes methods */
+@property(nonatomic) CoreDataStackErrorHandler defaultErrorBlock;
 
 /*! To use CoreData, you need to provide a permanent filename for it to save its sqlite DB to disk - or provide a manual URL to where
  you've already saved it. You also need to provide a model name


### PR DESCRIPTION
added a new property defaultErrorBlock for more convenient error handling especially when migration of a persistent store failed. Called whenever no other error handling block is explicitly passed as parameter to any of this classes methods.

Also added a method to replace the databaseURL on runtime while creating a backup. Could also be used as replacement of -(void)wipeAllData
